### PR TITLE
Remove the default of placement

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6022,7 +6022,6 @@ module VM_group = struct
           uid _vm_group
         ; namespace ~name:"name" ~contents:(names None RW) ()
         ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:placement_type "placement"
-            ~default_value:(Some (VEnum "normal"))
             "The placement type of the VM group"
         ; field ~qualifier:DynamicRO ~ty:(Set (Ref _vm)) "VMs"
             "The list of VMs currently associated with the group"

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -205,6 +205,8 @@ let _vm_guest_metrics = "VM_guest_metrics"
 
 let _vm_appliance = "VM_appliance"
 
+let _vm_group = "VM_group"
+
 let _dr_task = "DR_task"
 
 let _vmpp = "VMPP"

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1968,6 +1968,9 @@ let _ =
   error Api_errors.host_evacuation_is_required ["host"]
     ~doc:"Host evacuation is required before applying updates." () ;
 
+  error Api_errors.vm_can_only_belong_to_one_anti_affinity_group []
+    ~doc:"The VM can only belong to one anti-affinity group." () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1514,6 +1514,19 @@ let set_appliance =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let set_groups =
+  call ~name:"set_groups" ~in_product_since:rel_boston
+    ~doc:"Associate this VM with a VM group."
+    ~params:
+      [
+        (Ref _vm, "self", "The VM")
+      ; ( Set (Ref _vm_group)
+        , "value"
+        , "The VM groups to set (Only one anti-affinity group is supported now)"
+        )
+      ]
+    ~allowed_roles:_R_VM_ADMIN ()
+    
 let call_plugin =
   call ~name:"call_plugin" ~in_product_since:rel_cream
     ~doc:"Call an API plugin on this vm"
@@ -1826,6 +1839,7 @@ let t =
       ; recover
       ; import_convert
       ; set_appliance
+      ; set_groups
       ; query_services
       ; call_plugin
       ; set_has_vendor_device
@@ -2174,6 +2188,9 @@ let t =
              user should follow to make some updates, e.g. specific hardware \
              drivers or CPU features, fully effective, but the 'average user' \
              doesn't need to"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] 
+            ~ty:(Set (Ref _vm_group)) "groups"
+            "VM groups associated with the VM"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "186131ad48f40dff30246e8e0c0dbf0a"
+let last_known_schema_hash = "1d6e9eddb2feb79f45c2980bc30ce5d0"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -674,3 +674,10 @@ let make_observer ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
   Db.Observer.create ~__context ~ref ~uuid ~name_label ~name_description ~hosts
     ~attributes ~endpoints ~components ~enabled ;
   ref
+
+let make_vm_group ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
+    ?(name_label = "vm_group") ?(name_description = "") ?(placement = `normal)
+    () =
+  Db.VM_group.create ~__context ~ref ~uuid ~name_label ~name_description
+    ~placement ;
+  ref

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -46,6 +46,7 @@ let () =
      ; ("Test_storage_migrate_state", Test_storage_migrate_state.test)
      ; ("Test_bios_strings", Test_bios_strings.test)
      ; ("Test_certificates", Test_certificates.test)
+     ; ("Test_vm_group", Test_vm_group.test)
      ]
     @ Test_guest_agent.tests
     @ Test_nm.tests

--- a/ocaml/tests/test_vm_group.ml
+++ b/ocaml/tests/test_vm_group.ml
@@ -1,0 +1,56 @@
+(*
+ * Copyright (C) Cloud Software Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module T = Test_common
+
+let test_associate_vm_with_vm_group () =
+  let __context = T.make_test_database () in
+  let rpc, session_id = Test_common.make_client_params ~__context in
+  let vm1 = T.make_vm ~__context () in
+  let vm2 = T.make_vm ~__context () in
+  let vm3 = T.make_vm ~__context () in
+  let vm_group = T.make_vm_group ~__context ~placement:`anti_affinity () in
+  Client.Client.VM.set_groups ~rpc ~session_id ~self:vm1 ~value:[vm_group] ;
+  Client.Client.VM.set_groups ~rpc ~session_id ~self:vm2 ~value:[vm_group] ;
+  Client.Client.VM.set_groups ~rpc ~session_id ~self:vm3 ~value:[vm_group] ;
+  let vms = Db.VM_group.get_VMs ~__context ~self:vm_group in
+  let extract_vm_strings vms =
+    List.sort String.compare (List.map Ref.string_of vms)
+  in
+  Alcotest.(check (slist string String.compare))
+    "check VMs are in the group" (extract_vm_strings vms)
+    (extract_vm_strings [vm1; vm2; vm3])
+
+let test_vm_can_only_belong_to_one_anti_affinity_group () =
+  let __context = T.make_test_database () in
+  let rpc, session_id = Test_common.make_client_params ~__context in
+  let vm = T.make_vm ~__context () in
+  let vm_group1 = T.make_vm_group ~__context ~placement:`anti_affinity () in
+  let vm_group2 = T.make_vm_group ~__context ~placement:`anti_affinity () in
+  Alcotest.check_raises "should fail"
+    (Api_errors.Server_error (Api_errors.vm_can_only_belong_to_one_anti_affinity_group, []))
+    (fun () ->
+      Client.Client.VM.set_groups ~rpc ~session_id ~self:vm
+        ~value:[vm_group1; vm_group2]
+    ) ;
+  ()
+
+let test =
+  [
+    ("test_associate_vm_with_vm_group", `Quick, test_associate_vm_with_vm_group)
+  ; ( "test_vm_can_only_belong_to_one_anti_affinity_group"
+    , `Quick
+    , test_vm_can_only_belong_to_one_anti_affinity_group
+    )
+  ]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2647,6 +2647,24 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "vm-group-create"
+    , {
+        reqd= ["name-label"; "placement"]
+      ; optn= ["name-description"]
+      ; help= "Create a VM group."
+      ; implementation= No_fd Cli_operations.VM_group.create
+      ; flags= []
+      }
+    )
+  ; ( "vm-group-destroy"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Destroy a VM group."
+      ; implementation= No_fd Cli_operations.VM_group.destroy
+      ; flags= []
+      }
+    )
   ; ( "diagnostic-vm-status"
     , {
         reqd= ["uuid"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1140,6 +1140,11 @@ let gen_cmds rpc session_id =
         mk get_all_records_where get_by_uuid vm_appliance_record "appliance" []
           [] rpc session_id
       )
+    ; Client.VM_group.(
+        mk get_all_records_where get_by_uuid vm_group_record "vm-group" []
+          ["uuid"; "name-label"; "name-description"; "placement"; "VMs"]
+          rpc session_id
+      )
     ; Client.PGPU.(
         mk get_all_records_where get_by_uuid pgpu_record "pgpu" []
           ["uuid"; "vendor-name"; "device-name"; "gpu-group-uuid"]
@@ -7987,4 +7992,28 @@ module Observer = struct
     let uuid = List.assoc "uuid" params in
     let self = Client.Observer.get_by_uuid ~rpc ~session_id ~uuid in
     Client.Observer.destroy ~rpc ~session_id ~self
+end
+
+module VM_group = struct
+  let create printer rpc session_id params =
+    let name_label = List.assoc "name-label" params in
+    let name_description =
+      List.assoc_opt "name-description" params |> Option.value ~default:""
+    in
+    let placement =
+      Record_util.vm_placement_type_of_string (List.assoc "placement" params)
+    in
+    let ref =
+      Client.VM_group.create ~rpc ~session_id ~name_label ~name_description
+        ~placement
+    in
+    let uuid = Client.VM_group.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PList [uuid])
+
+  let destroy _printer rpc session_id params =
+    let ref =
+      Client.VM_group.get_by_uuid ~rpc ~session_id
+        ~uuid:(List.assoc "uuid" params)
+    in
+    Client.VM_group.destroy ~rpc ~session_id ~self:ref
 end

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1188,3 +1188,18 @@ let update_sync_frequency_of_string s =
       `weekly
   | _ ->
       raise (Record_failure ("Expected 'daily', 'weekly', got " ^ s))
+
+let vm_placement_type_to_string = function
+  | `normal ->
+      "normal"
+  | `anti_affinity ->
+      "anti-affinity"
+
+let vm_placement_type_of_string a =
+  match String.lowercase_ascii a with
+  | "normal" ->
+      `normal
+  | "anti-affinity" ->
+      `anti_affinity
+  | s ->
+      raise (Record_failure ("Invalid VM placement type, got " ^ s))

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2504,6 +2504,21 @@ let vm_record rpc session_id vm =
                 ~value:(Client.VM_appliance.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
+      ; make_field ~name:"groups"
+          ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_groups)
+          ~set:(fun x ->
+            if x = "" then
+              Client.VM.set_groups ~rpc ~session_id ~self:vm ~value:[]
+            else
+              let value = 
+                get_words ',' x
+                |> List.map (fun uuid ->
+                     Client.VM_group.get_by_uuid ~rpc ~session_id ~uuid
+                  )
+              in
+              Client.VM.set_groups ~rpc ~session_id ~self:vm ~value
+          )
+          ()
       ; make_field ~name:"snapshot-schedule"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_snapshot_schedule)
           ~set:(fun x ->
@@ -4065,6 +4080,57 @@ let vm_appliance_record rpc session_id vm_appliance =
             List.map
               (fun (_, b) -> Record_util.vm_appliance_operation_to_string b)
               (x ()).API.vM_appliance_current_operations
+          )
+          ()
+      ]
+  }
+
+let vm_group_record rpc session_id vm_group =
+  let _ref = ref vm_group in
+  let empty_record =
+    ToGet (fun () -> Client.VM_group.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vM_group_uuid) ()
+      ; make_field ~name:"name-label"
+          ~get:(fun () -> (x ()).API.vM_group_name_label)
+          ~set:(fun value ->
+            Client.VM_group.set_name_label ~rpc ~session_id ~self:!_ref
+              ~value
+          )
+          ()
+      ; make_field ~name:"name-description"
+          ~get:(fun () -> (x ()).API.vM_group_name_description)
+          ~set:(fun value ->
+            Client.VM_group.set_name_description ~rpc ~session_id
+              ~self:!_ref ~value
+          )
+          ()
+      ; make_field ~name:"placement"
+          ~get:(fun () ->
+            Record_util.vm_placement_type_to_string (x ()).API.vM_group_placement
+          )
+          ()
+      ; make_field ~name:"VMs"
+          ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_group_VMs)
+          ~get_set:(fun () ->
+            List.map get_uuid_from_ref (x ()).API.vM_group_VMs
           )
           ()
       ]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1299,3 +1299,5 @@ let telemetry_next_collection_too_late = "TELEMETRY_NEXT_COLLECTION_TOO_LATE"
 
 (* FIPS/CC_PREPARATIONS *)
 let illegal_in_fips_mode = "ILLEGAL_IN_FIPS_MODE"
+
+let vm_can_only_belong_to_one_anti_affinity_group = "VM_CAN_ONLY_BELONG_TO_ONE_ANTI_AFFINITY_GROUP"

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -39,6 +39,7 @@ module Actions = struct
   module VMPP = Xapi_vmpp
   module VMSS = Xapi_vmss
   module VM_appliance = Xapi_vm_appliance
+  module VM_group = Xapi_vm_group
   module DR_task = Xapi_dr_task
 
   module LVHD = struct end

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -416,6 +416,19 @@ functor
           Ref.string_of vm_appliance
       with _ -> "invalid"
 
+    let vm_group_uuid ~__context vm_group =
+      try
+        if Pool_role.is_master () then
+          let name =
+            Db.VM_group.get_name_label ~__context ~self:vm_group
+          in
+          Printf.sprintf "%s%s"
+            (Db.VM_group.get_uuid ~__context ~self:vm_group)
+            (add_brackets name)
+        else
+          Ref.string_of vm_group
+      with _ -> "invalid"
+
     let sr_uuid ~__context sr =
       try
         if Pool_role.is_master () then
@@ -2996,6 +3009,12 @@ functor
           (vm_appliance_uuid ~__context value) ;
         Local.VM.set_appliance ~__context ~self ~value
 
+      let set_groups ~__context ~self ~value =
+        info "VM.set_groups : pool = '%s'; value = [ %s ]"
+          (vm_uuid ~__context self)
+          (String.concat "; " (List.map (vm_group_uuid ~__context) value)) ;
+        Local.VM.set_groups ~__context ~self ~value
+  
       let import_convert ~__context ~_type ~username ~password ~sr
           ~remote_config =
         info "VM.import_convert: type = '%s'; remote_config = '%s;'" _type
@@ -6509,6 +6528,20 @@ functor
             Client.Repository.apply_livepatch ~rpc ~session_id ~host ~component
               ~base_build_id ~base_version ~base_release ~to_version ~to_release
         )
+    end
+
+    module VM_group = struct
+      (* include Local.VM_group *)
+
+      let create ~__context ~name_label ~name_description ~placement =
+        info
+          "VM_group.create: name = '%s'; name_description = '%s'"
+          name_label name_description ;
+        Local.VM_group.create ~__context ~name_label ~name_description ~placement
+
+      let destroy ~__context ~self =
+        info "VM_group.destroy: self = '%s'" (vm_group_uuid ~__context self) ;
+        Local.VM_group.destroy ~__context ~self 
     end
 
     module Observer = struct

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1444,6 +1444,17 @@ let set_appliance ~__context ~self ~value =
   (* Update the VM's allowed operations - this will update the new appliance's operations, if valid. *)
   update_allowed_operations ~__context ~self
 
+let set_groups ~__context ~self ~value =
+  let anti_affinity_group_cnt =
+    value
+    |> List.filter (fun group -> Db.VM_group.get_placement ~__context ~self:group = `anti_affinity)
+    |> List.length
+  in
+  if anti_affinity_group_cnt > 1 then
+    raise
+      (Api_errors.Server_error (Api_errors.vm_can_only_belong_to_one_anti_affinity_group, [])) ;
+  Db.VM.set_groups ~__context ~self ~value
+
 let import_convert ~__context ~_type ~username ~password ~sr ~remote_config =
   let open Vpx in
   let print_jobInstance (j : Vpx.jobInstance) =

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -372,6 +372,9 @@ val set_suspend_VDI :
 val set_appliance :
   __context:Context.t -> self:API.ref_VM -> value:API.ref_VM_appliance -> unit
 
+val set_groups :
+  __context:Context.t -> self:API.ref_VM -> value:API.ref_VM_group_set -> unit
+
 val import_convert :
      __context:Context.t
   -> _type:string

--- a/ocaml/xapi/xapi_vm_group.ml
+++ b/ocaml/xapi/xapi_vm_group.ml
@@ -1,0 +1,28 @@
+(*
+ * Copyright (C) Cloud Software Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Client
+
+module D = Debug.Make (struct let name = "xapi_vm_group" end)
+
+open D
+
+let create ~__context ~name_label ~name_description ~placement =
+  let uuid = Uuidx.make () in
+  let ref = Ref.make () in
+  Db.VM_group.create ~__context ~ref ~uuid:(Uuidx.to_string uuid)
+    ~name_label ~name_description ~placement ;
+  ref
+
+let destroy ~__context ~self = Db.VM_group.destroy ~__context ~self

--- a/ocaml/xapi/xapi_vm_group.mli
+++ b/ocaml/xapi/xapi_vm_group.mli
@@ -1,0 +1,22 @@
+(*
+ * Copyright (C) Cloud Software Group Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val create :
+     __context:Context.t
+  -> name_label:string
+  -> name_description:string
+  -> placement:API.vm_placement_type
+  -> [`VM_group] Ref.t
+
+val destroy : __context:Context.t -> self:[`VM_group] Ref.t -> unit

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -114,6 +114,7 @@ _xe()
                     pvs-site-*|\
                     sdn-controller-*|\
                     network-sriov-*|\
+                    vm-group-*|\
                     cluster-host-*)
                         # Chop off at the second '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-2)-list";;
@@ -384,6 +385,12 @@ _xe()
             update-sync-frequency) # for pool-configure-update-sync
                 IFS=$'\n,'
                 set_completions 'daily,weekly' "$value"
+                return 0
+                ;;
+
+            placement) # for vm-group-create
+                IFS=$'\n,'
+                set_completions 'normal,anti-affinity' "$value"
                 return 0
                 ;;
 


### PR DESCRIPTION
Remove the default of placement, but there is an error when building:
```
File "ocaml/idl/dune", line 80, characters 0-162:
80 | (rule
81 |  (deps gen_lifecycle.exe (universe))
82 |  (action (with-stdout-to datamodel_lifecycle.ml.generated (system %{project_root}/../../ocaml/idl/gen_lifecycle.exe))))
Fatal error: exception Failure("Field placement not in release Rio, is not DynamicRO and does not have default value specified")
make: *** [Makefile:15: build] Error 1
```